### PR TITLE
Makes cards responsive

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,7 +138,7 @@ export default function Home() {
           {sentences?.map(([term, definitions]) => (
             <div className="flex flex-col gap-4 border p-4 rounded" key={term}>
               <h4 className="font-bold text-3xl">{term}</h4>
-              <div className="grid grid-cols-5 gap-4">
+              <div className="flex flex-col md:grid md:grid-cols-5 xl:grid-cols-8 2xl:grid-cols-12 gap-4">
                 {definitions?.map(({ text, translation }) => (
                   <Sentence
                     key={`${text}:${translation}`}


### PR DESCRIPTION
This pull request updates the layout of the definitions section in the `Home` component to enhance responsiveness and improve the user experience across different screen sizes.

Layout improvements:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL141-R141): Changed the `div` containing definitions from a fixed grid layout to a responsive layout that adjusts between `flex` and `grid` depending on screen size, with additional column configurations for `xl` and `2xl` breakpoints.